### PR TITLE
Add `LiteJob::Server#kill` and `LiteJob::Server#exit` methods

### DIFF
--- a/lib/litejob/server.rb
+++ b/lib/litejob/server.rb
@@ -33,6 +33,14 @@ module Litejob
       result
     end
 
+    def kill
+      @scheduler&.context&.kill || false
+    end
+
+    def exit
+      @scheduler&.context&.exit || false
+    end
+
     def run!
       @scheduler.spawn do
         Litejob.logger.info("[litejob]:[RUN] id=#{@scheduler.context.object_id}")


### PR DESCRIPTION
This pull request adds two new methods `LiteJob::Server#kill` and `LiteJob::Server#exit` which can be used to stop a running `LiteJob::Server` instance.

Currently there is no public API to stop a `LiteJob::Server` from running and processing jobs, which this pull request is trying to address.